### PR TITLE
Add checkpointing to account for issues that arise from fictions with a high number of chapters

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,14 @@
+[target.x86_64-unknown-linux-gnu]
+linker = "gcc"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "gcc"
+
+[target.x86_64-pc-windows-gnu]
+linker = "x86_64-w64-mingw32-gcc"
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  release:
-    types: [published]
 
 env:
   CARGO_TERM_COLOR: always
@@ -37,90 +35,3 @@ jobs:
       
       - name: Run rustfmt
         run: cargo fmt -- --check
-
-  release:
-    name: Release
-    needs: build
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
-    
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustup
-      
-      - name: Build for Linux
-        run: |
-          cargo build --release --target x86_64-unknown-linux-gnu
-          cargo build --release --target aarch64-unknown-linux-gnu
-      
-      - name: Build for macOS
-        run: |
-          cargo build --release --target x86_64-apple-darwin
-          cargo build --release --target aarch64-apple-darwin
-      
-      - name: Build for Windows
-        run: |
-          cargo build --release --target x86_64-pc-windows-gnu
-      
-      - name: Create release archive
-        run: |
-          mkdir -p dist
-          tar -czf dist/rr-to-epub-linux-x86_64.tar.gz -C target/x86_64-unknown-linux-gnu/release rr-to-epub
-          tar -czf dist/rr-to-epub-linux-aarch64.tar.gz -C target/aarch64-unknown-linux-gnu/release rr-to-epub
-          tar -czf dist/rr-to-epub-macos-x86_64.tar.gz -C target/x86_64-apple-darwin/release rr-to-epub
-          tar -czf dist/rr-to-epub-macos-aarch64.tar.gz -C target/aarch64-apple-darwin/release rr-to-epub
-          zip -j dist/rr-to-epub-windows-x86_64.zip target/x86_64-pc-windows-gnu/release/rr-to-epub.exe
-      
-      - name: Upload release assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./dist/rr-to-epub-linux-x86_64.tar.gz
-          asset_name: rr-to-epub-linux-x86_64.tar.gz
-          asset_content_type: application/gzip
-      
-      - name: Upload release assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./dist/rr-to-epub-linux-aarch64.tar.gz
-          asset_name: rr-to-epub-linux-aarch64.tar.gz
-          asset_content_type: application/gzip
-      
-      - name: Upload release assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./dist/rr-to-epub-macos-x86_64.tar.gz
-          asset_name: rr-to-epub-macos-x86_64.tar.gz
-          asset_content_type: application/gzip
-      
-      - name: Upload release assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./dist/rr-to-epub-macos-aarch64.tar.gz
-          asset_name: rr-to-epub-macos-aarch64.tar.gz
-          asset_content_type: application/gzip
-      
-      - name: Upload release assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./dist/rr-to-epub-windows-x86_64.zip
-          asset_name: rr-to-epub-windows-x86_64.zip
-          asset_content_type: application/zip 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,126 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [published]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+      
+      - name: Build
+        run: cargo build --verbose
+      
+      - name: Run tests
+        run: cargo test --verbose
+      
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+      
+      - name: Run rustfmt
+        run: cargo fmt -- --check
+
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustup
+      
+      - name: Build for Linux
+        run: |
+          cargo build --release --target x86_64-unknown-linux-gnu
+          cargo build --release --target aarch64-unknown-linux-gnu
+      
+      - name: Build for macOS
+        run: |
+          cargo build --release --target x86_64-apple-darwin
+          cargo build --release --target aarch64-apple-darwin
+      
+      - name: Build for Windows
+        run: |
+          cargo build --release --target x86_64-pc-windows-gnu
+      
+      - name: Create release archive
+        run: |
+          mkdir -p dist
+          tar -czf dist/rr-to-epub-linux-x86_64.tar.gz -C target/x86_64-unknown-linux-gnu/release rr-to-epub
+          tar -czf dist/rr-to-epub-linux-aarch64.tar.gz -C target/aarch64-unknown-linux-gnu/release rr-to-epub
+          tar -czf dist/rr-to-epub-macos-x86_64.tar.gz -C target/x86_64-apple-darwin/release rr-to-epub
+          tar -czf dist/rr-to-epub-macos-aarch64.tar.gz -C target/aarch64-apple-darwin/release rr-to-epub
+          zip -j dist/rr-to-epub-windows-x86_64.zip target/x86_64-pc-windows-gnu/release/rr-to-epub.exe
+      
+      - name: Upload release assets
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./dist/rr-to-epub-linux-x86_64.tar.gz
+          asset_name: rr-to-epub-linux-x86_64.tar.gz
+          asset_content_type: application/gzip
+      
+      - name: Upload release assets
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./dist/rr-to-epub-linux-aarch64.tar.gz
+          asset_name: rr-to-epub-linux-aarch64.tar.gz
+          asset_content_type: application/gzip
+      
+      - name: Upload release assets
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./dist/rr-to-epub-macos-x86_64.tar.gz
+          asset_name: rr-to-epub-macos-x86_64.tar.gz
+          asset_content_type: application/gzip
+      
+      - name: Upload release assets
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./dist/rr-to-epub-macos-aarch64.tar.gz
+          asset_name: rr-to-epub-macos-aarch64.tar.gz
+          asset_content_type: application/gzip
+      
+      - name: Upload release assets
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./dist/rr-to-epub-windows-x86_64.zip
+          asset_name: rr-to-epub-windows-x86_64.zip
+          asset_content_type: application/zip 

--- a/README.md
+++ b/README.md
@@ -5,17 +5,29 @@
 
 A small application to convert a [Royal Road](https://www.royalroad.com/) story to an `.epub` file, compatible with readers such as Kindle or Calibre. Motivated by me wanting to read some stories on my Kindle when I'm without access to the Royal Road web service.
 
-## Install
+## Installation
 
-This tool is written in Rust. To install it, first install [Rust](https://www.rust-lang.org/tools/install), then run the following command:
+### From Pre-built Binaries
 
-```
+Pre-built binaries are available for various platforms in the [GitHub Releases](https://github.com/isaac-mcfadyen/rr-to-epub/releases) page:
+
+- Linux (x86_64 and aarch64)
+- macOS (x86_64 and aarch64)
+- Windows (x86_64)
+
+Download the appropriate archive for your platform and extract it. The binary will be named `rr-to-epub` (or `rr-to-epub.exe` on Windows).
+
+### From Source
+
+This tool is written in Rust. To install it from source, first install [Rust](https://www.rust-lang.org/tools/install), then run the following command:
+
+```sh
 cargo install --locked --git https://github.com/isaac-mcfadyen/rr-to-epub
 ```
 
 ## Usage
 
-After install, download a book by running the following command, substituting in the book URL:
+After installation, download a book by running the following command, substituting in the book URL:
 
 ```sh
 rr-to-epub download -u <URL>
@@ -28,3 +40,42 @@ rr-to-epub update -d <directory>
 ```
 
 Full help can be found by running `rr-to-epub --help`.
+
+## Development
+
+### Building from Source
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/isaac-mcfadyen/rr-to-epub.git
+   cd rr-to-epub
+   ```
+
+2. Build the project:
+   ```sh
+   cargo build --release
+   ```
+
+3. Run tests:
+   ```sh
+   cargo test
+   ```
+
+### CI/CD
+
+This project uses GitHub Actions for continuous integration and deployment:
+
+- On every push to main and pull requests:
+  - Builds the project
+  - Runs tests
+  - Checks code formatting with rustfmt
+  - Runs clippy for linting
+
+- On release publication:
+  - Builds binaries for all supported platforms
+  - Creates release archives
+  - Uploads the archives to GitHub Releases
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Full help can be found by running `rr-to-epub --help`.
    cargo test
    ```
 
-### CI/CD
+### CI
 
-This project uses GitHub Actions for continuous integration and deployment:
+This project uses GitHub Actions for continuous integration:
 
 - On every push to main and pull requests:
   - Builds the project
@@ -71,10 +71,6 @@ This project uses GitHub Actions for continuous integration and deployment:
   - Checks code formatting with rustfmt
   - Runs clippy for linting
 
-- On release publication:
-  - Builds binaries for all supported platforms
-  - Creates release archives
-  - Uploads the archives to GitHub Releases
 
 ## License
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -66,7 +66,7 @@ impl Cache {
     pub fn save_download_progress(book: &Book, last_processed_index: usize) -> eyre::Result<()> {
         let cache_dir = Self::cache_path()?.join(book.id.to_string());
         std::fs::create_dir_all(&cache_dir)?;
-        
+
         let progress_file = cache_dir.join("download_progress.json");
         let progress = serde_json::to_string(&last_processed_index)?;
         std::fs::write(progress_file, progress)?;
@@ -75,7 +75,9 @@ impl Cache {
 
     pub fn read_download_progress(book: &Book) -> eyre::Result<Option<usize>> {
         let cache_dir = Self::cache_path()?;
-        let progress_file = cache_dir.join(book.id.to_string()).join("download_progress.json");
+        let progress_file = cache_dir
+            .join(book.id.to_string())
+            .join("download_progress.json");
         if !progress_file.exists() {
             return Ok(None);
         }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -62,4 +62,25 @@ impl Cache {
         let contents = std::fs::read(cache_file)?;
         Ok(Some(contents.into()))
     }
+
+    pub fn save_download_progress(book: &Book, last_processed_index: usize) -> eyre::Result<()> {
+        let cache_dir = Self::cache_path()?.join(book.id.to_string());
+        std::fs::create_dir_all(&cache_dir)?;
+        
+        let progress_file = cache_dir.join("download_progress.json");
+        let progress = serde_json::to_string(&last_processed_index)?;
+        std::fs::write(progress_file, progress)?;
+        Ok(())
+    }
+
+    pub fn read_download_progress(book: &Book) -> eyre::Result<Option<usize>> {
+        let cache_dir = Self::cache_path()?;
+        let progress_file = cache_dir.join(book.id.to_string()).join("download_progress.json");
+        if !progress_file.exists() {
+            return Ok(None);
+        }
+        let contents = std::fs::read_to_string(progress_file)?;
+        let progress: usize = serde_json::from_str(&contents)?;
+        Ok(Some(progress))
+    }
 }

--- a/src/epub.rs
+++ b/src/epub.rs
@@ -158,11 +158,20 @@ impl Book {
         // at the start or the end in the HTML.
         let authors_note_start_selector = Selector::parse("hr + .portlet > .author-note").unwrap();
         let authors_note_end_selector = Selector::parse("div + .portlet > .author-note").unwrap();
-        for (index, chapter) in self.chapters.iter_mut().enumerate() {
+
+        // Check for existing progress
+        let start_index = Cache::read_download_progress(self)?.unwrap_or(0);
+        if start_index > 0 {
+            tracing::info!("Resuming download from chapter {} of {}", start_index + 1, num_chapters);
+        }
+
+        let mut current_index = start_index;
+        while current_index < num_chapters {
+            let chapter = &mut self.chapters[current_index];
             tracing::info!(
                 "Downloading chapter '{}' ({} of {})",
                 chapter.title,
-                index + 1,
+                current_index + 1,
                 num_chapters
             );
             let url = format!("https://www.royalroad.com{}", chapter.url);
@@ -206,9 +215,26 @@ impl Book {
                 }
             }
 
+            // Save progress every 100 chapters
+            if (current_index + 1) % 100 == 0 {
+                tracing::info!("Saving checkpoint at chapter {} of {}", current_index + 1, num_chapters);
+                Cache::save_download_progress(self, current_index + 1)?;
+                Cache::write_book(self)?;
+            }
+
             // Sleep for 0.5 seconds to avoid rate limiting.
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            
+            current_index += 1;
         }
+
+        // Clear the progress file when done
+        let cache_dir = Cache::cache_path()?.join(self.id.to_string());
+        let progress_file = cache_dir.join("download_progress.json");
+        if progress_file.exists() {
+            std::fs::remove_file(progress_file)?;
+        }
+
         Ok(())
     }
 }
@@ -819,15 +845,28 @@ async fn download_image(book: &Book, url: String, file: &mut impl Write) -> eyre
         }
         None => {
             let client = reqwest::Client::new();
-            let image = client
+            let image = match client
                 .get(&url)
                 .header("User-Agent", USER_AGENT)
                 .send()
-                .await?;
+                .await
+            {
+                Ok(response) => response,
+                Err(e) => {
+                    // Handle DNS and connection errors gracefully
+                    tracing::warn!(
+                        "Failed to download image from URL ({}): {}. This is likely NOT a bug with rr-to-epub.",
+                        url,
+                        e
+                    );
+                    return Ok(());
+                }
+            };
+            
             if !image.status().is_success() {
-                // Ignore failed images.
                 tracing::warn!(
-                    "Failed to download image from URL. This is likely NOT a bug with rr-to-epub. URL: {}",
+                    "Failed to download image from URL (HTTP {}): {}. This is likely NOT a bug with rr-to-epub.",
+                    image.status(),
                     url
                 );
                 return Ok(());

--- a/src/epub.rs
+++ b/src/epub.rs
@@ -162,7 +162,11 @@ impl Book {
         // Check for existing progress
         let start_index = Cache::read_download_progress(self)?.unwrap_or(0);
         if start_index > 0 {
-            tracing::info!("Resuming download from chapter {} of {}", start_index + 1, num_chapters);
+            tracing::info!(
+                "Resuming download from chapter {} of {}",
+                start_index + 1,
+                num_chapters
+            );
         }
 
         let mut current_index = start_index;
@@ -217,14 +221,18 @@ impl Book {
 
             // Save progress every 100 chapters
             if (current_index + 1) % 100 == 0 {
-                tracing::info!("Saving checkpoint at chapter {} of {}", current_index + 1, num_chapters);
+                tracing::info!(
+                    "Saving checkpoint at chapter {} of {}",
+                    current_index + 1,
+                    num_chapters
+                );
                 Cache::save_download_progress(self, current_index + 1)?;
                 Cache::write_book(self)?;
             }
 
             // Sleep for 0.5 seconds to avoid rate limiting.
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-            
+
             current_index += 1;
         }
 
@@ -862,7 +870,7 @@ async fn download_image(book: &Book, url: String, file: &mut impl Write) -> eyre
                     return Ok(());
                 }
             };
-            
+
             if !image.status().is_success() {
                 tracing::warn!(
                     "Failed to download image from URL (HTTP {}): {}. This is likely NOT a bug with rr-to-epub.",

--- a/src/xml_ext.rs
+++ b/src/xml_ext.rs
@@ -1,13 +1,13 @@
 use std::io::Write;
-use xml::EventWriter;
 use xml::writer::XmlEvent;
+use xml::EventWriter;
 
 pub fn write_elements(
-	writer: &mut EventWriter<&mut (impl Write + Sized)>,
-	elements: Vec<XmlEvent>,
+    writer: &mut EventWriter<&mut (impl Write + Sized)>,
+    elements: Vec<XmlEvent>,
 ) -> eyre::Result<()> {
-	for element in elements {
-		writer.write(element)?;
-	}
-	Ok(())
+    for element in elements {
+        writer.write(element)?;
+    }
+    Ok(())
 }


### PR DESCRIPTION
When books have a high number of chapters (think 400+) there is a potential for client error. After experiencing this I realized that there was no way to restart at point of failure so the download repeatedly failed. Added in checkpointing and while I was at it, added some CICD